### PR TITLE
Add commit pinning to Github Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Ensure Clippy is available
         run: rustup component add clippy


### PR DESCRIPTION
# Why
- Commit pinning adds extra security.

# How
- Pin the checkout version to the hash of https://github.com/actions/checkout/releases/tag/v4.2.2
